### PR TITLE
Add Python 3.14 to CI matrix and verify compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,15 +10,13 @@ Unreleased Version
 ------------------
 
 **Added**
+- Python 3.14 added to CI test matrix and ``pyproject.toml`` classifiers
 - ``split()`` method — split an image into its individual bands:
-
-  - Returns a ``tuple[Image, ...]`` matching Pillow's exact return type
-  - Each band is an independent L-mode (grayscale) copy
-  - Supported for all modes: ``L``, ``LA``, ``RGB``, ``RGBA``
-  - GIL released during channel extraction; LLVM-vectorisable hot path
-
+- Returns a ``tuple[Image, ...]`` matching Pillow's exact return type
+- Each band is an independent L-mode (grayscale) copy
+- Supported for all modes: ``L``, ``LA``, ``RGB``, ``RGBA``
+- GIL released during channel extraction; LLVM-vectorisable hot path
 - ``getbands()`` method — return band name tuple (e.g. ``('R', 'G', 'B')``)
-
 - ``Image.new()`` now accepts 2-tuple ``(luma, alpha)`` color for ``LA`` mode images
 
 Version 0.3.0 (Current)
@@ -27,13 +25,12 @@ Version 0.3.0 (Current)
 **Added**
 
 - ``paste()`` method for image composition with full Pillow compatibility:
-
-  - 2-tuple and 4-tuple box coordinates
-  - Negative coordinates with automatic clipping
-  - Color fills via RGB/RGBA tuples, single integers, or color strings
-  - Mask-based alpha blending
-  - Abbreviated syntax ``paste(im, mask)``
-  - Automatic mode conversion between source and destination
+- 2-tuple and 4-tuple box coordinates
+- Negative coordinates with automatic clipping
+- Color fills via RGB/RGBA tuples, single integers, or color strings
+- Mask-based alpha blending
+- Abbreviated syntax ``paste(im, mask)``
+- Automatic mode conversion between source and destination
 
 Version 0.2.2
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## What is solved?
Added Python 3.14 to the CI test matrix to ensure puhu builds and passes all tests on it.

### Changes

- Added to the python-version matrix (now covers 3.8–3.14 across all three OSes)
- Python :: 3.13 and Python :: 3.14 classifiers added (3.13 was also missing)

## Checklist

- [x] Connected to Issue #16 
- [x] Changelog updated
